### PR TITLE
Generate tile jsonld sitemap

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -130,7 +130,14 @@ defaults:
       # sidebar:        # Possible values › left, right › by default there will be no sidebar
       comments: false
       author: selvaje74    # Default author for posts
-
+  -
+    scope:
+      path: '' 				# an empty string here means all files in the project
+      type: 'jsonld'
+    values:
+      show_meta: false 	# Hide metadata for all pages
+      # sidebar:    		# Possible values › left, right › by default there will be no sidebar
+      comments: false
 
 
 #       _   __            _             __  _
@@ -213,7 +220,7 @@ msapplication_tilecolor              : '#fabb00'
 #
 # used in _includes/comments
 
-# disqus_shortname: 
+# disqus_shortname:
 
 
 #      _____
@@ -273,7 +280,7 @@ sass:
 
 asciidoctor-enabled: false
 asciidoctor:
-  description: 
+  description:
   attributes:
     source-highlighter: coderay
     coderay-css: style

--- a/jsonld/hydrograph_tile_h00v00.json
+++ b/jsonld/hydrograph_tile_h00v00.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h00v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h00v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h00v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h00v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h00v02.json
+++ b/jsonld/hydrograph_tile_h00v02.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h00v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h00v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h00v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h00v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h00v02.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h00v04.json
+++ b/jsonld/hydrograph_tile_h00v04.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h00v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h00v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h00v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h00v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h00v04.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h00v06.json
+++ b/jsonld/hydrograph_tile_h00v06.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h00v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h00v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h00v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h00v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h00v06.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h00v10.json
+++ b/jsonld/hydrograph_tile_h00v10.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h00v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h00v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h00v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h00v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h00v10.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h00v12.json
+++ b/jsonld/hydrograph_tile_h00v12.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h00v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h00v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h00v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h00v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h00v12.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h02v00.json
+++ b/jsonld/hydrograph_tile_h02v00.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h02v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h02v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h02v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h02v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h02v00.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h02v02.json
+++ b/jsonld/hydrograph_tile_h02v02.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h02v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h02v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h02v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h02v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h02v02.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h02v06.json
+++ b/jsonld/hydrograph_tile_h02v06.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h02v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h02v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h02v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h02v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h02v06.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h02v08.json
+++ b/jsonld/hydrograph_tile_h02v08.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h02v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h02v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h02v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h02v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h02v08.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h02v10.json
+++ b/jsonld/hydrograph_tile_h02v10.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h02v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h02v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h02v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h02v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h02v10.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h04v00.json
+++ b/jsonld/hydrograph_tile_h04v00.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h04v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h04v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h04v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h04v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h04v00.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h04v02.json
+++ b/jsonld/hydrograph_tile_h04v02.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h04v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h04v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h04v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h04v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h04v02.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h04v04.json
+++ b/jsonld/hydrograph_tile_h04v04.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h04v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h04v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h04v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h04v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h04v04.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h04v08.json
+++ b/jsonld/hydrograph_tile_h04v08.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h04v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h04v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h04v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h04v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h04v08.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h04v10.json
+++ b/jsonld/hydrograph_tile_h04v10.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h04v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h04v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h04v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h04v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h04v10.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h06v00.json
+++ b/jsonld/hydrograph_tile_h06v00.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h06v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h06v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h06v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h06v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h06v00.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h06v02.json
+++ b/jsonld/hydrograph_tile_h06v02.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h06v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h06v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h06v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h06v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h06v02.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h06v04.json
+++ b/jsonld/hydrograph_tile_h06v04.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h06v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h06v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h06v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h06v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h06v04.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h06v06.json
+++ b/jsonld/hydrograph_tile_h06v06.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h06v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h06v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h06v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h06v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h06v06.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h06v10.json
+++ b/jsonld/hydrograph_tile_h06v10.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h06v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h06v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h06v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h06v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h06v10.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h08v00.json
+++ b/jsonld/hydrograph_tile_h08v00.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h08v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h08v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h08v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h08v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h08v00.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h08v02.json
+++ b/jsonld/hydrograph_tile_h08v02.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h08v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h08v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h08v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h08v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h08v02.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h08v04.json
+++ b/jsonld/hydrograph_tile_h08v04.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h08v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h08v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h08v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h08v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h08v04.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h08v06.json
+++ b/jsonld/hydrograph_tile_h08v06.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h08v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h08v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h08v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h08v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h08v06.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h08v08.json
+++ b/jsonld/hydrograph_tile_h08v08.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h08v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h08v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h08v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h08v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h08v08.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h08v10.json
+++ b/jsonld/hydrograph_tile_h08v10.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h08v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h08v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h08v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h08v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h08v10.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h10v00.json
+++ b/jsonld/hydrograph_tile_h10v00.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h10v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h10v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h10v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h10v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h10v00.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h10v02.json
+++ b/jsonld/hydrograph_tile_h10v02.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h10v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h10v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h10v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h10v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h10v02.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h10v04.json
+++ b/jsonld/hydrograph_tile_h10v04.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h10v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h10v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h10v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h10v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h10v04.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h10v06.json
+++ b/jsonld/hydrograph_tile_h10v06.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h10v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h10v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h10v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h10v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h10v06.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h10v08.json
+++ b/jsonld/hydrograph_tile_h10v08.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h10v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h10v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h10v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h10v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h10v08.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h10v10.json
+++ b/jsonld/hydrograph_tile_h10v10.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h10v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h10v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h10v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h10v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h10v10.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h10v12.json
+++ b/jsonld/hydrograph_tile_h10v12.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h10v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h10v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h10v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h10v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h10v12.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h12v00.json
+++ b/jsonld/hydrograph_tile_h12v00.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h12v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h12v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h12v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h12v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h12v00.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h12v02.json
+++ b/jsonld/hydrograph_tile_h12v02.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h12v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h12v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h12v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h12v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h12v02.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h12v04.json
+++ b/jsonld/hydrograph_tile_h12v04.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h12v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h12v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h12v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h12v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h12v04.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h12v06.json
+++ b/jsonld/hydrograph_tile_h12v06.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h12v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h12v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h12v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h12v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h12v06.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h12v08.json
+++ b/jsonld/hydrograph_tile_h12v08.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h12v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h12v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h12v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h12v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h12v08.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h12v10.json
+++ b/jsonld/hydrograph_tile_h12v10.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h12v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h12v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h12v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h12v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h12v10.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h12v12.json
+++ b/jsonld/hydrograph_tile_h12v12.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h12v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h12v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h12v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h12v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h12v12.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h14v00.json
+++ b/jsonld/hydrograph_tile_h14v00.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h14v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h14v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h14v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h14v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h14v00.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h14v02.json
+++ b/jsonld/hydrograph_tile_h14v02.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h14v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h14v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h14v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h14v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h14v02.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h14v04.json
+++ b/jsonld/hydrograph_tile_h14v04.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h14v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h14v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h14v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h14v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h14v04.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h14v06.json
+++ b/jsonld/hydrograph_tile_h14v06.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h14v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h14v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h14v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h14v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h14v06.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h14v08.json
+++ b/jsonld/hydrograph_tile_h14v08.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h14v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h14v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h14v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h14v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h14v08.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h14v10.json
+++ b/jsonld/hydrograph_tile_h14v10.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h14v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h14v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h14v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h14v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h14v10.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h14v12.json
+++ b/jsonld/hydrograph_tile_h14v12.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h14v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h14v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h14v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h14v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h14v12.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h16v00.json
+++ b/jsonld/hydrograph_tile_h16v00.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h16v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h16v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h16v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h16v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h16v00.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h16v02.json
+++ b/jsonld/hydrograph_tile_h16v02.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h16v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h16v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h16v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h16v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h16v02.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h16v04.json
+++ b/jsonld/hydrograph_tile_h16v04.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h16v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h16v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h16v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h16v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h16v04.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h16v06.json
+++ b/jsonld/hydrograph_tile_h16v06.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h16v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h16v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h16v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h16v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h16v06.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h16v08.json
+++ b/jsonld/hydrograph_tile_h16v08.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h16v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h16v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h16v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h16v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h16v08.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h16v10.json
+++ b/jsonld/hydrograph_tile_h16v10.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h16v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h16v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h16v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h16v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h16v10.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h16v12.json
+++ b/jsonld/hydrograph_tile_h16v12.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h16v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h16v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h16v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h16v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h16v12.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h18v00.json
+++ b/jsonld/hydrograph_tile_h18v00.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h18v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h18v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h18v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h18v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h18v00.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h18v02.json
+++ b/jsonld/hydrograph_tile_h18v02.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h18v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h18v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h18v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h18v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h18v02.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h18v04.json
+++ b/jsonld/hydrograph_tile_h18v04.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h18v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h18v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h18v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h18v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h18v04.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h18v06.json
+++ b/jsonld/hydrograph_tile_h18v06.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h18v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h18v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h18v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h18v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h18v06.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h18v08.json
+++ b/jsonld/hydrograph_tile_h18v08.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h18v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h18v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h18v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h18v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h18v08.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h18v10.json
+++ b/jsonld/hydrograph_tile_h18v10.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h18v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h18v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h18v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h18v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h18v10.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h18v12.json
+++ b/jsonld/hydrograph_tile_h18v12.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h18v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h18v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h18v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h18v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h18v12.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h20v00.json
+++ b/jsonld/hydrograph_tile_h20v00.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h20v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h20v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h20v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h20v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h20v00.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h20v02.json
+++ b/jsonld/hydrograph_tile_h20v02.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h20v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h20v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h20v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h20v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h20v02.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h20v04.json
+++ b/jsonld/hydrograph_tile_h20v04.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h20v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h20v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h20v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h20v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h20v04.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h20v06.json
+++ b/jsonld/hydrograph_tile_h20v06.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h20v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h20v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h20v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h20v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h20v06.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h20v08.json
+++ b/jsonld/hydrograph_tile_h20v08.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h20v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h20v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h20v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h20v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h20v08.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h20v10.json
+++ b/jsonld/hydrograph_tile_h20v10.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h20v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h20v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h20v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h20v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h20v10.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h20v12.json
+++ b/jsonld/hydrograph_tile_h20v12.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h20v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h20v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h20v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h20v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h20v12.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h22v00.json
+++ b/jsonld/hydrograph_tile_h22v00.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h22v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h22v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h22v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h22v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h22v00.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h22v02.json
+++ b/jsonld/hydrograph_tile_h22v02.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h22v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h22v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h22v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h22v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h22v02.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h22v04.json
+++ b/jsonld/hydrograph_tile_h22v04.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h22v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h22v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h22v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h22v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h22v04.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h22v06.json
+++ b/jsonld/hydrograph_tile_h22v06.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h22v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h22v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h22v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h22v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h22v06.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h22v08.json
+++ b/jsonld/hydrograph_tile_h22v08.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h22v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h22v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h22v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h22v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h22v08.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h22v10.json
+++ b/jsonld/hydrograph_tile_h22v10.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h22v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h22v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h22v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h22v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h22v10.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h22v12.json
+++ b/jsonld/hydrograph_tile_h22v12.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h22v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h22v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h22v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h22v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h22v12.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h24v00.json
+++ b/jsonld/hydrograph_tile_h24v00.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h24v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h24v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h24v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h24v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h24v00.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h24v02.json
+++ b/jsonld/hydrograph_tile_h24v02.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h24v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h24v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h24v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h24v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h24v02.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h24v04.json
+++ b/jsonld/hydrograph_tile_h24v04.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h24v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h24v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h24v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h24v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h24v04.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h24v06.json
+++ b/jsonld/hydrograph_tile_h24v06.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h24v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h24v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h24v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h24v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h24v06.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h24v08.json
+++ b/jsonld/hydrograph_tile_h24v08.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h24v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h24v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h24v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h24v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h24v08.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h24v10.json
+++ b/jsonld/hydrograph_tile_h24v10.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h24v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h24v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h24v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h24v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h24v10.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h24v12.json
+++ b/jsonld/hydrograph_tile_h24v12.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h24v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h24v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h24v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h24v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h24v12.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h26v00.json
+++ b/jsonld/hydrograph_tile_h26v00.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h26v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h26v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h26v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h26v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h26v00.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h26v02.json
+++ b/jsonld/hydrograph_tile_h26v02.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h26v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h26v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h26v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h26v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h26v02.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h26v04.json
+++ b/jsonld/hydrograph_tile_h26v04.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h26v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h26v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h26v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h26v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h26v04.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h26v06.json
+++ b/jsonld/hydrograph_tile_h26v06.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h26v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h26v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h26v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h26v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h26v06.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h26v08.json
+++ b/jsonld/hydrograph_tile_h26v08.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h26v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h26v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h26v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h26v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h26v08.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h28v00.json
+++ b/jsonld/hydrograph_tile_h28v00.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h28v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h28v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h28v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h28v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h28v00.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h28v02.json
+++ b/jsonld/hydrograph_tile_h28v02.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h28v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h28v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h28v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h28v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h28v02.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h28v04.json
+++ b/jsonld/hydrograph_tile_h28v04.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h28v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h28v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h28v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h28v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h28v04.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h28v06.json
+++ b/jsonld/hydrograph_tile_h28v06.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h28v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h28v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h28v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h28v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h28v06.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h28v08.json
+++ b/jsonld/hydrograph_tile_h28v08.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h28v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h28v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h28v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h28v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h28v08.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h28v10.json
+++ b/jsonld/hydrograph_tile_h28v10.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h28v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h28v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h28v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h28v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h28v10.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h28v12.json
+++ b/jsonld/hydrograph_tile_h28v12.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h28v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h28v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h28v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h28v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h28v12.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h30v00.json
+++ b/jsonld/hydrograph_tile_h30v00.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h30v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h30v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h30v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h30v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h30v00.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h30v02.json
+++ b/jsonld/hydrograph_tile_h30v02.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h30v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h30v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h30v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h30v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h30v02.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h30v04E.json
+++ b/jsonld/hydrograph_tile_h30v04E.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h30v04E.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h30v04E.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h30v04E.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h30v04E.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h30v04E.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h30v06.json
+++ b/jsonld/hydrograph_tile_h30v06.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h30v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h30v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h30v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h30v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h30v06.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h30v08.json
+++ b/jsonld/hydrograph_tile_h30v08.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h30v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h30v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h30v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h30v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h30v08.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h30v10.json
+++ b/jsonld/hydrograph_tile_h30v10.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h30v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h30v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h30v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h30v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h30v10.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h30v12.json
+++ b/jsonld/hydrograph_tile_h30v12.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h30v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h30v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h30v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h30v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h30v12.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h32v00.json
+++ b/jsonld/hydrograph_tile_h32v00.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h32v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h32v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h32v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h32v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h32v00.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h32v02.json
+++ b/jsonld/hydrograph_tile_h32v02.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h32v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h32v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h32v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h32v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h32v02.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h32v04.json
+++ b/jsonld/hydrograph_tile_h32v04.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h32v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h32v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h32v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h32v04.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h32v04.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h32v06.json
+++ b/jsonld/hydrograph_tile_h32v06.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h32v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h32v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h32v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h32v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h32v06.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h32v08.json
+++ b/jsonld/hydrograph_tile_h32v08.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h32v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h32v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h32v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h32v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h32v08.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h32v10.json
+++ b/jsonld/hydrograph_tile_h32v10.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h32v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h32v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h32v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h32v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h32v10.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h32v12.json
+++ b/jsonld/hydrograph_tile_h32v12.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h32v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h32v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h32v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h32v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h32v12.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h34v00.json
+++ b/jsonld/hydrograph_tile_h34v00.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h34v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h34v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h34v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h34v00.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h34v00.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h34v02.json
+++ b/jsonld/hydrograph_tile_h34v02.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h34v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h34v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h34v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h34v02.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h34v02.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h34v06.json
+++ b/jsonld/hydrograph_tile_h34v06.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h34v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h34v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h34v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h34v06.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h34v06.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h34v08.json
+++ b/jsonld/hydrograph_tile_h34v08.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h34v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h34v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h34v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h34v08.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h34v08.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h34v10.json
+++ b/jsonld/hydrograph_tile_h34v10.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h34v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h34v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h34v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h34v10.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h34v10.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/hydrograph_tile_h34v12.json
+++ b/jsonld/hydrograph_tile_h34v12.json
@@ -1,0 +1,376 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "url": "{site.url}{page.url}",
+  "name": "page.title",
+  "description": "{{ page.excerpt | strip_newlines | strip | jsonify }}",
+  "isAccessibleForFree": true,
+  "keywords": "{{ page.tags | join: ',' | jsonify }}",
+  "datePublished": "{{ page.date | jsonify }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | jsonify }}",
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "https://orcid.org/0000-0002-8341-2830",
+        "name": "Giuseppe Amatulli",
+        "url": "https://orcid.org/0000-0002-8341-2830"
+      }
+    ]
+  },
+  "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+  "version": "1",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2001-08-06/2002-09-09",
+  "spatialCoverage": {
+    "@type": "Place",
+    "geo": {
+      "@type": "GeoShape",
+      "box": "-68.4817 -75.8183 -65.08 -68.5033"
+    },
+    "additionalProperty": [
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+        "name": "well-known text (WKT) representation of geometry",
+        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+      },
+      {
+        "@type": "PropertyValue",
+        "propertyID": "http://www.wikidata.org/entity/Q161779",
+        "name": "Spatial Reference System",
+        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      }
+    ]
+  },
+  "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "name": "time_sample",
+      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+      "unitText": "minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "name": "pigment_content",
+      "description": "pigment content",
+      "unitText": "micrograms total chl/grams wet weight"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "name": "stage_id",
+      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "name": "wet_weight",
+      "description": "average wet weight/larvae in sample",
+      "unitText": "mg"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "name": "lat",
+      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "name": "lon",
+      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+      "unitText": "decimal degrees"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "name": "day_local",
+      "description": "day of month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "name": "month_local",
+      "description": "month, local time"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "name": "time_local",
+      "description": "time of day, local time, using 2400 clock format"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "name": "yrday_local",
+      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+    }
+  ],
+  "funding": {
+    "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "@type": "MonetaryGrant",
+    "identifier": "9909933",
+    "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+    "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+    "funder": {
+      "@id": "http://dx.doi.org/10.13039/100000001",
+      "@type": "Organization",
+      "name": "National Science Foundation",
+      "identifier": [
+        "http://dx.doi.org/10.13039/100000001",
+        "https://ror.org/021nxhr62"
+      ]
+    }
+  },
+  "distributions": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h34v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h34v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h34v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h34v12.gpkg",
+      "encodingFormat": "application/geopackage+vnd.sqlite3"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    },
+    {
+      "@type": "DataDownload",
+      "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h34v12.tif",
+      "encodingFormat": "image/tiff"
+    }
+  ]
+}

--- a/jsonld/sitemap_json.xml
+++ b/jsonld/sitemap_json.xml
@@ -1,0 +1,348 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+        <sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h00v00.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h02v00.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h04v00.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h06v00.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h08v00.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h10v00.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h12v00.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h14v00.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h16v00.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h18v00.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h20v00.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h22v00.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h24v00.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h26v00.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h28v00.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h30v00.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h32v00.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h34v00.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h00v02.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h02v02.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h04v02.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h06v02.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h08v02.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h10v02.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h12v02.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h14v02.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h16v02.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h18v02.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h20v02.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h22v02.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h24v02.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h26v02.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h28v02.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h30v02.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h32v02.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h34v02.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h00v04.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h04v04.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h06v04.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h08v04.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h10v04.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h12v04.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h14v04.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h16v04.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h18v04.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h20v04.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h22v04.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h24v04.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h26v04.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h28v04.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h30v04E.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h32v04.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h00v06.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h02v06.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h06v06.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h08v06.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h10v06.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h12v06.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h14v06.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h16v06.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h18v06.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h20v06.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h22v06.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h24v06.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h26v06.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h28v06.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h30v06.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h32v06.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h34v06.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h02v08.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h04v08.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h08v08.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h10v08.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h12v08.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h14v08.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h16v08.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h18v08.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h20v08.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h22v08.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h24v08.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h26v08.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h28v08.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h30v08.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h32v08.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h34v08.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h00v10.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h02v10.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h04v10.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h06v10.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h08v10.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h10v10.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h12v10.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h14v10.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h16v10.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h18v10.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h20v10.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h22v10.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h24v10.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h28v10.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h30v10.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h32v10.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h34v10.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h00v12.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h10v12.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h12v12.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h14v12.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h16v12.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h18v12.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h20v12.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h22v12.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h24v12.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h28v12.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h30v12.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h32v12.json</loc>
+  </sitemap> 
+<sitemap>
+    <loc>https://earthcube.github.io/hydrography.org/jsonld/hydrograph_tile_h34v12.json</loc>
+  </sitemap> 
+</sitemapindex>

--- a/jsonld_notes.md
+++ b/jsonld_notes.md
@@ -1,0 +1,8 @@
+
+Thoughts.
+
+distributions... visualizations
+    if the visualization is a web page, maybe that should be the url of the dataset?
+
+Do we want to add a data catalog pointing to all the dataset jsonLD.
+or three, one for types , one for tiles, one pointing to type and tiles datacatalogs

--- a/pages/hydrography90m/hydrography90m_layers.md
+++ b/pages/hydrography90m/hydrography90m_layers.md
@@ -7,384 +7,7 @@ header:
    image_fullwidth: "hydrography90m/dem_streamOrder1.jpg"
 ---
 
-<script type="application/ld+json">
-{
-    "@context": "https://schema.org",
-    "@type": "Dataset",
-    "url": "{{ site.url }}{{ page.url }}",
-    "name": {{ page.title | jsonify }},
-    "description": {{ page.excerpt | strip_newlines | strip | jsonify }},
-    "isAccessibleForFree": true,
-    "keywords": {{ page.tags | join: ',' | jsonify }},
-    "datePublished": {{ page.date | jsonify }},
-    "dateModified": {{ page.last_modified_at | default: page.date | jsonify }},
-    "creator": {
-        "@list": [
-          {
-            "@type": "Person",
-            "@id": "https://orcid.org/0000-0002-8341-2830",
-            "name": "Giuseppe Amatulli",
-            "url": "https://orcid.org/0000-0002-8341-2830"
-          }
-        ]
-    },
-    "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
-    "version": "1",
-    "license": "https://creativecommons.org/licenses/by/4.0/",
-    "temporalCoverage": "2001-08-06/2002-09-09",
-      "spatialCoverage": {
-        "@type": "Place",
-        "geo": {
-          "@type": "GeoShape",
-          "box": "-68.4817 -75.8183 -65.08 -68.5033"
-        },
-        "additionalProperty": [
-          {
-            "@type": "PropertyValue",
-            "propertyID": "http://www.wikidata.org/entity/Q4018860",
-            "name": "well-known text (WKT) representation of geometry",
-            "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
-          },
-          {
-            "@type": "PropertyValue",
-            "propertyID": "http://www.wikidata.org/entity/Q161779",
-            "name": "Spatial Reference System",
-            "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
-          }
-        ]
-      },
-    "variableMeasured": [
-    {
-      "@type": "PropertyValue",
-      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
-      "name": "cruiseid",
-      "description": "cruise identification",
-      "unitText": "text"
-    },
-    {
-      "@type": "PropertyValue",
-      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
-      "name": "year",
-      "description": "year of experiment",
-      "unitText": "calendar year"
-    },
-    {
-      "@type": "PropertyValue",
-      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
-      "name": "sample_id",
-      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
-    },
-    {
-      "@type": "PropertyValue",
-      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
-      "name": "time_sample",
-      "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
-      "unitText": "minutes"
-    },
-    {
-      "@type": "PropertyValue",
-      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
-      "name": "pigment_content",
-      "description": "pigment content",
-      "unitText": "micrograms total chl/grams wet weight"
-    },
-    {
-      "@type": "PropertyValue",
-      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
-      "name": "stage_id",
-      "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
-    },
-    {
-      "@type": "PropertyValue",
-      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
-      "name": "wet_weight",
-      "description": "average wet weight/larvae in sample",
-      "unitText": "mg"
-    },
-    {
-      "@type": "PropertyValue",
-      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
-      "name": "lat",
-      "description": "latitude, in decimal degrees, North is positive, negative denotes South",
-      "unitText": "decimal degrees"
-    },
-    {
-      "@type": "PropertyValue",
-      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
-      "name": "lon",
-      "description": "longitude, in decimal degrees, East is positive, negative denotes West",
-      "unitText": "decimal degrees"
-    },
-    {
-      "@type": "PropertyValue",
-      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
-      "name": "day_local",
-      "description": "day of month, local time"
-    },
-    {
-      "@type": "PropertyValue",
-      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
-      "name": "month_local",
-      "description": "month, local time"
-    },
-    {
-      "@type": "PropertyValue",
-      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
-      "name": "time_local",
-      "description": "time of day, local time, using 2400 clock format"
-    },
-    {
-      "@type": "PropertyValue",
-      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
-      "name": "yrday_local",
-      "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
-    }
-    ],
-    "funding":{
-      "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
-      "@type": "MonetaryGrant",
-      "identifier": "9909933",
-      "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
-      "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
-      "funder": {
-          "@id": "http://dx.doi.org/10.13039/100000001",
-          "@type": "Organization",
-          "name": "National Science Foundation",
-          "identifier": [
-            "http://dx.doi.org/10.13039/100000001",
-            "https://ror.org/021nxhr62"
-          ]
-      }
-    },
-    "distribution": [
-        {
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h00v00.gpkg",
-  "encodingFormat": "application/geopackage+vnd.sqlite3"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h00v00.gpkg",
-  "encodingFormat": "application/geopackage+vnd.sqlite3"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h00v00.gpkg",
-  "encodingFormat": "application/geopackage+vnd.sqlite3"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h00v00.gpkg",
-  "encodingFormat": "application/geopackage+vnd.sqlite3"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h00v00.tif",
-  "encodingFormat": "image/tiff"
-},
-{
-  "@type": "DataDownload",
-  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h00v00.tif",
-  "encodingFormat": "image/tiff"
-}
-]
-}
-</script>
+
 
 Here is an overview of all the current layers of the Hydrography90m dataset.
 Please see the paper by [Amatulli et al. (2022)](https://essd.copernicus.org/articles/14/4525/2022/essd-14-4525-2022.html) for further details.  
@@ -961,7 +584,102 @@ The depression layer is stored at [r.watershed](https://public.igb-berlin.de/ind
 <table style="width:100% background-image= none">
 	<tr>
 		<th colspan="2" style="font-size: 25px;">Elevation</th>
+<script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "Dataset",
+    "url": "{{ site.url }}{{ page.url }}",
+    "name": "Elevation",
+    "description": "Input layers to derive the Hydrography90m: MERIT HYDRO DEM, depression",
+    "isAccessibleForFree": true,
+    "keywords": ["KEYWORDS FOR DATASET"],
+
+    "creator": {
+        "@list": [
+          {
+            "@type": "Person",
+            "@id": "https://orcid.org/0000-0002-8341-2830",
+            "name": "Giuseppe Amatulli",
+            "url": "https://orcid.org/0000-0002-8341-2830"
+          }
+        ]
+    },
+    "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+    "version": "1",
+    "license": "https://creativecommons.org/licenses/by/4.0/",
+    "temporalCoverage": "2001-08-06/2002-09-09",
+      "spatialCoverage": {
+        "@type": "Place",
+        "geo": {
+          "@type": "GeoShape",
+          "box": "-68.4817 -75.8183 -65.08 -68.5033"
+        },
+        "additionalProperty": [
+          {
+            "@type": "PropertyValue",
+            "propertyID": "http://www.wikidata.org/entity/Q4018860",
+            "name": "well-known text (WKT) representation of geometry",
+            "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+          },
+          {
+            "@type": "PropertyValue",
+            "propertyID": "http://www.wikidata.org/entity/Q161779",
+            "name": "Spatial Reference System",
+            "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+          }
+        ]
+      },
+    "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+  
+    ],
+    "funding":{
+      "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+      "@type": "MonetaryGrant",
+      "identifier": "9909933",
+      "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+      "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+      "funder": {
+          "@id": "http://dx.doi.org/10.13039/100000001",
+          "@type": "Organization",
+          "name": "National Science Foundation",
+          "identifier": [
+            "http://dx.doi.org/10.13039/100000001",
+            "https://ror.org/021nxhr62"
+          ]
+      }
+    },
+    "distribution": [
+        {
+                  "@type": "DataDownload",
+                  "contentUrl": "http://hydro.iis.u-tokyo.ac.jp/~yamadai/MERIT_Hydro/",
+                  "encodingFormat": "image/tiff"
+                }
+
+    ]
+    }
+</script>
 	</tr>
+
 	<tr>
 		<td rowspan="1">
 			<img src="/images/hydrography90m/layer_images/Fig6/elevation.png" alt="elv_*.tif" width="320" />
@@ -974,7 +692,102 @@ The depression layer is stored at [r.watershed](https://public.igb-berlin.de/ind
 	</tr>
 	<tr>
 		<th colspan="2" style="font-size: 25px;">Depression</th>
+<script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "Dataset",
+    "url": "{{ site.url }}{{ page.url }}",
+    "name": "Depression",
+    "description": "Input layers to derive the Hydrography90m: MERIT HYDRO DEM, depression",
+    "isAccessibleForFree": true,
+    "keywords": ["KEYWORDS FOR DATASET"],
+
+    "creator": {
+        "@list": [
+          {
+            "@type": "Person",
+            "@id": "https://orcid.org/0000-0002-8341-2830",
+            "name": "Giuseppe Amatulli",
+            "url": "https://orcid.org/0000-0002-8341-2830"
+          }
+        ]
+    },
+    "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+    "version": "1",
+    "license": "https://creativecommons.org/licenses/by/4.0/",
+    "temporalCoverage": "2001-08-06/2002-09-09",
+      "spatialCoverage": {
+        "@type": "Place",
+        "geo": {
+          "@type": "GeoShape",
+          "box": "-68.4817 -75.8183 -65.08 -68.5033"
+        },
+        "additionalProperty": [
+          {
+            "@type": "PropertyValue",
+            "propertyID": "http://www.wikidata.org/entity/Q4018860",
+            "name": "well-known text (WKT) representation of geometry",
+            "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+          },
+          {
+            "@type": "PropertyValue",
+            "propertyID": "http://www.wikidata.org/entity/Q161779",
+            "name": "Spatial Reference System",
+            "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+          }
+        ]
+      },
+    "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+  
+    ],
+    "funding":{
+      "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+      "@type": "MonetaryGrant",
+      "identifier": "9909933",
+      "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+      "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+      "funder": {
+          "@id": "http://dx.doi.org/10.13039/100000001",
+          "@type": "Organization",
+          "name": "National Science Foundation",
+          "identifier": [
+            "http://dx.doi.org/10.13039/100000001",
+            "https://ror.org/021nxhr62"
+          ]
+      }
+    },
+    "distribution": [
+        {
+                  "@type": "DataDownload",
+                  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4?path=%2Fr.watershed%2Fdepression_tiles20d",
+                  "encodingFormat": "image/tiff"
+                }
+
+    ]
+    }
+</script>
 	</tr>
+
 	<tr>
 		<th>Depression areas not present in the study area.</th>
 		<td><br><br>
@@ -1001,6 +814,104 @@ These files are stored in the [r.watershed](https://public.igb-berlin.de/index.p
 <table style="width:100% background-image= none">
 	<tr>
 		<th colspan="2" style="font-size: 25px;">Flow accumulation</th>
+<script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "Dataset",
+    "url": "{{ site.url }}{{ page.url }}",
+    "name": "Depression",
+    "description": "Input layers to derive the Hydrography90m: MERIT HYDRO DEM, depression",
+    "isAccessibleForFree": true,
+    "keywords": ["KEYWORDS FOR DATASET"],
+
+    "creator": {
+        "@list": [
+          {
+            "@type": "Person",
+            "@id": "https://orcid.org/0000-0002-8341-2830",
+            "name": "Giuseppe Amatulli",
+            "url": "https://orcid.org/0000-0002-8341-2830"
+          }
+        ]
+    },
+    "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+    "version": "1",
+    "license": "https://creativecommons.org/licenses/by/4.0/",
+    "temporalCoverage": "2001-08-06/2002-09-09",
+      "spatialCoverage": {
+        "@type": "Place",
+        "geo": {
+          "@type": "GeoShape",
+          "box": "-68.4817 -75.8183 -65.08 -68.5033"
+        },
+        "additionalProperty": [
+          {
+            "@type": "PropertyValue",
+            "propertyID": "http://www.wikidata.org/entity/Q4018860",
+            "name": "well-known text (WKT) representation of geometry",
+            "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+          },
+          {
+            "@type": "PropertyValue",
+            "propertyID": "http://www.wikidata.org/entity/Q161779",
+            "name": "Spatial Reference System",
+            "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+          }
+        ]
+      },
+    "variableMeasured": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "name": "cruiseid",
+      "description": "cruise identification",
+      "unitText": "text"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "name": "year",
+      "description": "year of experiment",
+      "unitText": "calendar year"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "name": "sample_id",
+      "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+    },
+  
+    ],
+    "funding":{
+      "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+      "@type": "MonetaryGrant",
+      "identifier": "9909933",
+      "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+      "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+      "funder": {
+          "@id": "http://dx.doi.org/10.13039/100000001",
+          "@type": "Organization",
+          "name": "National Science Foundation",
+          "identifier": [
+            "http://dx.doi.org/10.13039/100000001",
+            "https://ror.org/021nxhr62"
+          ]
+      }
+    },
+    "distribution": [
+        {
+                  "@type": "DataDownload",
+                  "contentUrl": "https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4?path=%2Fr.watershed%2Faccumulation_tiles20d",
+                  "encodingFormat": "image/tiff"
+                },
+    {
+                  "@type": "DataDownload",
+                  "contentUrl": "https://geo.igb-berlin.de/maps/new?layer=geonode:hydrography90m_v1_accumulation_cog&view=True",
+                  "encodingFormat": "text/html"
+                }
+    ]
+    }
+</script>
 	</tr>
 	<tr>
 		<td rowspan="1">

--- a/pages/hydrography90m/print-json-ld.js
+++ b/pages/hydrography90m/print-json-ld.js
@@ -1,67 +1,364 @@
+const fs = require('fs')
+
 const baseUrls = [
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_h${h}v${v}.gpkg',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_h${h}v${v}.gpkg',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_h${h}v${v}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fbasin_tiles20d&files=basin_${tile}.gpkg',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsegment_tiles20d&files=segment_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fsub_catchment_tiles20d&files=sub_catchment_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Foutlet_tiles20d&files=outlet_${tile}.gpkg',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_max_dw_cel_tiles20d&files=slope_curv_max_dw_cel_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_curv_min_dw_cel_tiles20d&files=slope_curv_min_dw_cel_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_elv_dw_cel_tiles20d&files=slope_elv_dw_cel_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.slope%2Fslope_grad_dw_cel_tiles20d&files=slope_grad_dw_cel_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_near_tiles20d&files=stream_dist_up_near_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_up_farth_tiles20d&files=stream_dist_up_farth_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_dw_near_tiles20d&files=stream_dist_dw_near_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_basin_tiles20d&files=outlet_dist_dw_basin_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_dist_dw_scatch_tiles20d&files=outlet_dist_dw_scatch_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_dist_proximity_tiles20d&files=stream_dist_proximity_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_near_tiles20d&files=stream_diff_up_near_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_up_farth_tiles20d&files=stream_diff_up_farth_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Fstream_diff_dw_near_tiles20d&files=stream_diff_dw_near_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_basin_tiles20d&files=outlet_diff_dw_basin_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.distance%2Foutlet_diff_dw_scatch_tiles20d&files=outlet_diff_dw_scatch_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_dw_seg_tiles20d&files=channel_grad_dw_seg_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_seg_tiles20d&files=channel_grad_up_seg_${tile}.tif',
     'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_grad_up_cel_tiles20d&files=channel_grad_up_cel_h00v00.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_h${h}v${v}.gpkg',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_h${h}v${v}.gpkg',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_h${h}v${v}.tif',
-    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_h${h}v${v}.tif'
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_curv_cel_tiles20d&files=channel_curv_cel_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_seg_tiles20d&files=channel_elv_dw_seg_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_seg_tiles20d&files=channel_elv_up_seg_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_up_cel_tiles20d&files=channel_elv_up_cel_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_elv_dw_cel_tiles20d&files=channel_elv_dw_cel_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_dw_seg_tiles20d&files=channel_dist_dw_seg_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_seg_tiles20d&files=channel_dist_up_seg_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.channel%2Fchannel_dist_up_cel_tiles20d&files=channel_dist_up_cel_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_strahler_tiles20d&files=order_strahler_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_shreve_tiles20d&files=order_shreve_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_horton_tiles20d&files=order_horton_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_hack_tiles20d&files=order_hack_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_topo_tiles20d&files=order_topo_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_point_${tile}.gpkg',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.stream.order%2Forder_vect_tiles20d&files=order_vect_segment_${tile}.gpkg',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fspi_tiles20d&files=spi_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fsti_tiles20d&files=sti_${tile}.tif',
+    'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_${tile}.tif'
 ];
 
-const indexes = ['00', '02', '04', '06','08', '10','12','14','16','18','20','22','24','26','28','30','32','34'];
-for (const h in indexes) {
-    for (const v in indexes) {
-        for (const baseUrl of baseUrls) {
-            const specificUrl = baseUrl.replace(/\${h}/g, indexes[h]).replace(/\${v}/g, indexes[v]);
-            console.log("{\n" +
-                "  \"@type\": \"DataDownload\",\n" +
-                "  \"contentUrl\": \"" + specificUrl + "\",");
-            if (specificUrl.endsWith(".gpkg")) {
-                console.log("  \"encodingFormat\": \"application/geopackage+vnd.sqlite3\"\n" +
-                    "},");
-            } else {
-                console.log("  \"encodingFormat\": \"image/tiff\"\n" +
-                    "},");
+const tiles = [ "h00v00"
+,"h02v00" 
+,"h04v00" 
+,"h06v00" 
+,"h08v00" 
+,"h10v00" 
+,"h12v00" 
+,"h14v00" 
+,"h16v00" 
+,"h18v00" 
+,"h20v00" 
+,"h22v00" 
+,"h24v00" 
+,"h26v00" 
+,"h28v00" 
+,"h30v00" 
+,"h32v00" 
+,"h34v00" 
+
+,"h00v02" 
+,"h02v02" 
+,"h04v02" 
+,"h06v02" 
+,"h08v02" 
+,"h10v02" 
+,"h12v02" 
+,"h14v02" 
+,"h16v02" 
+,"h18v02" 
+,"h20v02" 
+,"h22v02" 
+,"h24v02" 
+,"h26v02" 
+,"h28v02" 
+,"h30v02" 
+,"h32v02" 
+,"h34v02" 
+
+,"h00v04" 
+,"h04v04" 
+,"h06v04" 
+,"h08v04" 
+,"h10v04" 
+,"h12v04" 
+,"h14v04" 
+,"h16v04" 
+,"h18v04" 
+,"h20v04" 
+,"h22v04" 
+,"h24v04" 
+,"h26v04" 
+,"h28v04" 
+,"h30v04E" 
+,"h32v04" 
+
+,"h00v06" 
+,"h02v06" 
+,"h06v06" 
+,"h08v06" 
+,"h10v06" 
+,"h12v06" 
+,"h14v06" 
+,"h16v06" 
+,"h18v06" 
+,"h20v06" 
+,"h22v06" 
+,"h24v06" 
+,"h26v06" 
+,"h28v06" 
+,"h30v06" 
+,"h32v06" 
+,"h34v06" 
+
+,"h02v08" 
+,"h04v08" 
+,"h08v08" 
+,"h10v08" 
+,"h12v08" 
+,"h14v08" 
+,"h16v08" 
+,"h18v08" 
+,"h20v08" 
+,"h22v08" 
+,"h24v08" 
+,"h26v08" 
+,"h28v08" 
+,"h30v08" 
+,"h32v08" 
+,"h34v08" 
+
+,"h00v10" 
+,"h02v10" 
+,"h04v10" 
+,"h06v10" 
+,"h08v10" 
+,"h10v10" 
+,"h12v10" 
+,"h14v10" 
+,"h16v10" 
+,"h18v10" 
+,"h20v10" 
+,"h22v10" 
+,"h24v10" 
+,"h28v10" 
+,"h30v10" 
+,"h32v10" 
+,"h34v10" 
+
+,"h00v12" 
+,"h10v12" 
+,"h12v12" 
+,"h14v12" 
+,"h16v12" 
+,"h18v12" 
+,"h20v12" 
+,"h22v12" 
+,"h24v12" 
+,"h28v12" 
+,"h30v12" 
+,"h32v12" 
+,"h34v12"
+     ]
+
+
+    for (let tile in tiles) {
+        const header = {
+            "@context": "https://schema.org",
+            "@type": "Dataset",
+            "url": `{site.url}{page.url}`,
+            "name": `page.title`,
+            "description": `{{ page.excerpt | strip_newlines | strip | jsonify }}`,
+            "isAccessibleForFree": true,
+            "keywords": `{{ page.tags | join: ',' | jsonify }}`,
+            "datePublished": `{{ page.date | jsonify }}`,
+            "dateModified": `{{ page.last_modified_at | default: page.date | jsonify }}`,
+            "creator": {
+                "@list": [
+                    {
+                        "@type": "Person",
+                        "@id": "https://orcid.org/0000-0002-8341-2830",
+                        "name": "Giuseppe Amatulli",
+                        "url": "https://orcid.org/0000-0002-8341-2830"
+                    }
+                ]
+            },
+            "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+            "version": "1",
+            "license": "https://creativecommons.org/licenses/by/4.0/",
+            "temporalCoverage": "2001-08-06/2002-09-09",
+            "spatialCoverage": {
+                "@type": "Place",
+                "geo": {
+                    "@type": "GeoShape",
+                    "box": "-68.4817 -75.8183 -65.08 -68.5033"
+                },
+                "additionalProperty": [
+                    {
+                        "@type": "PropertyValue",
+                        "propertyID": "http://www.wikidata.org/entity/Q4018860",
+                        "name": "well-known text (WKT) representation of geometry",
+                        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+                    },
+                    {
+                        "@type": "PropertyValue",
+                        "propertyID": "http://www.wikidata.org/entity/Q161779",
+                        "name": "Spatial Reference System",
+                        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                    }
+                ]
+            },
+            "variableMeasured": [
+                {
+                    "@type": "PropertyValue",
+                    "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+                    "name": "cruiseid",
+                    "description": "cruise identification",
+                    "unitText": "text"
+                },
+                {
+                    "@type": "PropertyValue",
+                    "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+                    "name": "year",
+                    "description": "year of experiment",
+                    "unitText": "calendar year"
+                },
+                {
+                    "@type": "PropertyValue",
+                    "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+                    "name": "sample_id",
+                    "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+                },
+                {
+                    "@type": "PropertyValue",
+                    "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+                    "name": "time_sample",
+                    "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+                    "unitText": "minutes"
+                },
+                {
+                    "@type": "PropertyValue",
+                    "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+                    "name": "pigment_content",
+                    "description": "pigment content",
+                    "unitText": "micrograms total chl/grams wet weight"
+                },
+                {
+                    "@type": "PropertyValue",
+                    "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+                    "name": "stage_id",
+                    "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+                },
+                {
+                    "@type": "PropertyValue",
+                    "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+                    "name": "wet_weight",
+                    "description": "average wet weight/larvae in sample",
+                    "unitText": "mg"
+                },
+                {
+                    "@type": "PropertyValue",
+                    "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+                    "name": "lat",
+                    "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+                    "unitText": "decimal degrees"
+                },
+                {
+                    "@type": "PropertyValue",
+                    "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+                    "name": "lon",
+                    "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+                    "unitText": "decimal degrees"
+                },
+                {
+                    "@type": "PropertyValue",
+                    "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+                    "name": "day_local",
+                    "description": "day of month, local time"
+                },
+                {
+                    "@type": "PropertyValue",
+                    "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+                    "name": "month_local",
+                    "description": "month, local time"
+                },
+                {
+                    "@type": "PropertyValue",
+                    "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+                    "name": "time_local",
+                    "description": "time of day, local time, using 2400 clock format"
+                },
+                {
+                    "@type": "PropertyValue",
+                    "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+                    "name": "yrday_local",
+                    "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+                }
+            ],
+            "funding": {
+                "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+                "@type": "MonetaryGrant",
+                "identifier": "9909933",
+                "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+                "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+                "funder": {
+                    "@id": "http://dx.doi.org/10.13039/100000001",
+                    "@type": "Organization",
+                    "name": "National Science Foundation",
+                    "identifier": [
+                        "http://dx.doi.org/10.13039/100000001",
+                        "https://ror.org/021nxhr62"
+                    ]
+                }
             }
         }
+
+        let dists = []
+        for (const baseUrl of baseUrls) {
+            const specificUrl = baseUrl.replace(/\${tiles[tile]}/g, tiles[tile]);
+            let dist = {
+                '@type' : "DataDownload",
+                "contentUrl":specificUrl,
+            }
+            if (specificUrl.endsWith(".gpkg")) {
+                dist["encodingFormat"]= "application/geopackage+vnd.sqlite3";
+            } else {
+                dist["encodingFormat"]= "image/tiff";
+            }
+            dists.push(dist)
+            // console.log("{\n" +
+            //     "  \"@type\": \"DataDownload\",\n" +
+            //     "  \"contentUrl\": \"" + specificUrl + "\",");
+            // if (specificUrl.endsWith(".gpkg")) {
+            //     console.log("  \"encodingFormat\": \"application/geopackage+vnd.sqlite3\"\n" +
+            //         "},");
+            // } else {
+            //     console.log("  \"encodingFormat\": \"image/tiff\"\n" +
+            //         "},");
+            // }
+        }
+        let jsonObj = header
+        jsonObj["distributions"] = dists
+       // const distribution = JSON.stringify(dists,undefined, 2)
+       // const output = `${header} , "distributions": ${distribution}`
+        //console.log(output)
+        let output =JSON.stringify(jsonObj,undefined, 2)
+        console.log(output)
+        fs.writeFile(`jsonld/hydrograph_tile_${tiles[tile]}.json`, output, (err) => {
+
+            // In case of a error throw err.
+            if (err) throw err;
+        })
     }
-}
+
 

--- a/pages/hydrography90m/print-json-ld.js
+++ b/pages/hydrography90m/print-json-ld.js
@@ -1,6 +1,8 @@
 const fs = require('fs')
 
-const baseUrls = [
+const baseUrl = "https://earthcube.github.io/hydrography.org/"
+
+const tileUrls = [
     'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdepression_tiles20d&files=depression_${tile}.tif',
     'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Faccumulation_tiles20d&files=accumulation_${tile}.tif',
     'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fr.watershed%2Fdirection_tiles20d&files=direction_${tile}.tif',
@@ -48,317 +50,335 @@ const baseUrls = [
     'https://public.igb-berlin.de/index.php/s/agciopgzXjWswF4/download?path=%2Fflow.index%2Fcti_tiles20d&files=cti_${tile}.tif'
 ];
 
-const tiles = [ "h00v00"
-,"h02v00" 
-,"h04v00" 
-,"h06v00" 
-,"h08v00" 
-,"h10v00" 
-,"h12v00" 
-,"h14v00" 
-,"h16v00" 
-,"h18v00" 
-,"h20v00" 
-,"h22v00" 
-,"h24v00" 
-,"h26v00" 
-,"h28v00" 
-,"h30v00" 
-,"h32v00" 
-,"h34v00" 
+const tiles = ["h00v00"
+    , "h02v00"
+    , "h04v00"
+    , "h06v00"
+    , "h08v00"
+    , "h10v00"
+    , "h12v00"
+    , "h14v00"
+    , "h16v00"
+    , "h18v00"
+    , "h20v00"
+    , "h22v00"
+    , "h24v00"
+    , "h26v00"
+    , "h28v00"
+    , "h30v00"
+    , "h32v00"
+    , "h34v00"
 
-,"h00v02" 
-,"h02v02" 
-,"h04v02" 
-,"h06v02" 
-,"h08v02" 
-,"h10v02" 
-,"h12v02" 
-,"h14v02" 
-,"h16v02" 
-,"h18v02" 
-,"h20v02" 
-,"h22v02" 
-,"h24v02" 
-,"h26v02" 
-,"h28v02" 
-,"h30v02" 
-,"h32v02" 
-,"h34v02" 
+    , "h00v02"
+    , "h02v02"
+    , "h04v02"
+    , "h06v02"
+    , "h08v02"
+    , "h10v02"
+    , "h12v02"
+    , "h14v02"
+    , "h16v02"
+    , "h18v02"
+    , "h20v02"
+    , "h22v02"
+    , "h24v02"
+    , "h26v02"
+    , "h28v02"
+    , "h30v02"
+    , "h32v02"
+    , "h34v02"
 
-,"h00v04" 
-,"h04v04" 
-,"h06v04" 
-,"h08v04" 
-,"h10v04" 
-,"h12v04" 
-,"h14v04" 
-,"h16v04" 
-,"h18v04" 
-,"h20v04" 
-,"h22v04" 
-,"h24v04" 
-,"h26v04" 
-,"h28v04" 
-,"h30v04E" 
-,"h32v04" 
+    , "h00v04"
+    , "h04v04"
+    , "h06v04"
+    , "h08v04"
+    , "h10v04"
+    , "h12v04"
+    , "h14v04"
+    , "h16v04"
+    , "h18v04"
+    , "h20v04"
+    , "h22v04"
+    , "h24v04"
+    , "h26v04"
+    , "h28v04"
+    , "h30v04E"
+    , "h32v04"
 
-,"h00v06" 
-,"h02v06" 
-,"h06v06" 
-,"h08v06" 
-,"h10v06" 
-,"h12v06" 
-,"h14v06" 
-,"h16v06" 
-,"h18v06" 
-,"h20v06" 
-,"h22v06" 
-,"h24v06" 
-,"h26v06" 
-,"h28v06" 
-,"h30v06" 
-,"h32v06" 
-,"h34v06" 
+    , "h00v06"
+    , "h02v06"
+    , "h06v06"
+    , "h08v06"
+    , "h10v06"
+    , "h12v06"
+    , "h14v06"
+    , "h16v06"
+    , "h18v06"
+    , "h20v06"
+    , "h22v06"
+    , "h24v06"
+    , "h26v06"
+    , "h28v06"
+    , "h30v06"
+    , "h32v06"
+    , "h34v06"
 
-,"h02v08" 
-,"h04v08" 
-,"h08v08" 
-,"h10v08" 
-,"h12v08" 
-,"h14v08" 
-,"h16v08" 
-,"h18v08" 
-,"h20v08" 
-,"h22v08" 
-,"h24v08" 
-,"h26v08" 
-,"h28v08" 
-,"h30v08" 
-,"h32v08" 
-,"h34v08" 
+    , "h02v08"
+    , "h04v08"
+    , "h08v08"
+    , "h10v08"
+    , "h12v08"
+    , "h14v08"
+    , "h16v08"
+    , "h18v08"
+    , "h20v08"
+    , "h22v08"
+    , "h24v08"
+    , "h26v08"
+    , "h28v08"
+    , "h30v08"
+    , "h32v08"
+    , "h34v08"
 
-,"h00v10" 
-,"h02v10" 
-,"h04v10" 
-,"h06v10" 
-,"h08v10" 
-,"h10v10" 
-,"h12v10" 
-,"h14v10" 
-,"h16v10" 
-,"h18v10" 
-,"h20v10" 
-,"h22v10" 
-,"h24v10" 
-,"h28v10" 
-,"h30v10" 
-,"h32v10" 
-,"h34v10" 
+    , "h00v10"
+    , "h02v10"
+    , "h04v10"
+    , "h06v10"
+    , "h08v10"
+    , "h10v10"
+    , "h12v10"
+    , "h14v10"
+    , "h16v10"
+    , "h18v10"
+    , "h20v10"
+    , "h22v10"
+    , "h24v10"
+    , "h28v10"
+    , "h30v10"
+    , "h32v10"
+    , "h34v10"
 
-,"h00v12" 
-,"h10v12" 
-,"h12v12" 
-,"h14v12" 
-,"h16v12" 
-,"h18v12" 
-,"h20v12" 
-,"h22v12" 
-,"h24v12" 
-,"h28v12" 
-,"h30v12" 
-,"h32v12" 
-,"h34v12"
-     ]
+    , "h00v12"
+    , "h10v12"
+    , "h12v12"
+    , "h14v12"
+    , "h16v12"
+    , "h18v12"
+    , "h20v12"
+    , "h22v12"
+    , "h24v12"
+    , "h28v12"
+    , "h30v12"
+    , "h32v12"
+    , "h34v12"
+]
 
+let sitemapFiles = []
 
-    for (let tile in tiles) {
-        const header = {
-            "@context": "https://schema.org",
-            "@type": "Dataset",
-            "url": `{site.url}{page.url}`,
-            "name": `page.title`,
-            "description": `{{ page.excerpt | strip_newlines | strip | jsonify }}`,
-            "isAccessibleForFree": true,
-            "keywords": `{{ page.tags | join: ',' | jsonify }}`,
-            "datePublished": `{{ page.date | jsonify }}`,
-            "dateModified": `{{ page.last_modified_at | default: page.date | jsonify }}`,
-            "creator": {
-                "@list": [
-                    {
-                        "@type": "Person",
-                        "@id": "https://orcid.org/0000-0002-8341-2830",
-                        "name": "Giuseppe Amatulli",
-                        "url": "https://orcid.org/0000-0002-8341-2830"
-                    }
-                ]
-            },
-            "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
-            "version": "1",
-            "license": "https://creativecommons.org/licenses/by/4.0/",
-            "temporalCoverage": "2001-08-06/2002-09-09",
-            "spatialCoverage": {
-                "@type": "Place",
-                "geo": {
-                    "@type": "GeoShape",
-                    "box": "-68.4817 -75.8183 -65.08 -68.5033"
-                },
-                "additionalProperty": [
-                    {
-                        "@type": "PropertyValue",
-                        "propertyID": "http://www.wikidata.org/entity/Q4018860",
-                        "name": "well-known text (WKT) representation of geometry",
-                        "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
-                    },
-                    {
-                        "@type": "PropertyValue",
-                        "propertyID": "http://www.wikidata.org/entity/Q161779",
-                        "name": "Spatial Reference System",
-                        "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
-                    }
-                ]
-            },
-            "variableMeasured": [
+for (let tile in tiles) {
+    const header = {
+        "@context": "https://schema.org",
+        "@type": "Dataset",
+        "url": `{site.url}{page.url}`,
+        "name": `page.title`,
+        "description": `{{ page.excerpt | strip_newlines | strip | jsonify }}`,
+        "isAccessibleForFree": true,
+        "keywords": `{{ page.tags | join: ',' | jsonify }}`,
+        "datePublished": `{{ page.date | jsonify }}`,
+        "dateModified": `{{ page.last_modified_at | default: page.date | jsonify }}`,
+        "creator": {
+            "@list": [
                 {
-                    "@type": "PropertyValue",
-                    "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
-                    "name": "cruiseid",
-                    "description": "cruise identification",
-                    "unitText": "text"
-                },
-                {
-                    "@type": "PropertyValue",
-                    "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
-                    "name": "year",
-                    "description": "year of experiment",
-                    "unitText": "calendar year"
-                },
-                {
-                    "@type": "PropertyValue",
-                    "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
-                    "name": "sample_id",
-                    "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
-                },
-                {
-                    "@type": "PropertyValue",
-                    "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
-                    "name": "time_sample",
-                    "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
-                    "unitText": "minutes"
-                },
-                {
-                    "@type": "PropertyValue",
-                    "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
-                    "name": "pigment_content",
-                    "description": "pigment content",
-                    "unitText": "micrograms total chl/grams wet weight"
-                },
-                {
-                    "@type": "PropertyValue",
-                    "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
-                    "name": "stage_id",
-                    "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
-                },
-                {
-                    "@type": "PropertyValue",
-                    "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
-                    "name": "wet_weight",
-                    "description": "average wet weight/larvae in sample",
-                    "unitText": "mg"
-                },
-                {
-                    "@type": "PropertyValue",
-                    "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
-                    "name": "lat",
-                    "description": "latitude, in decimal degrees, North is positive, negative denotes South",
-                    "unitText": "decimal degrees"
-                },
-                {
-                    "@type": "PropertyValue",
-                    "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
-                    "name": "lon",
-                    "description": "longitude, in decimal degrees, East is positive, negative denotes West",
-                    "unitText": "decimal degrees"
-                },
-                {
-                    "@type": "PropertyValue",
-                    "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
-                    "name": "day_local",
-                    "description": "day of month, local time"
-                },
-                {
-                    "@type": "PropertyValue",
-                    "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
-                    "name": "month_local",
-                    "description": "month, local time"
-                },
-                {
-                    "@type": "PropertyValue",
-                    "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
-                    "name": "time_local",
-                    "description": "time of day, local time, using 2400 clock format"
-                },
-                {
-                    "@type": "PropertyValue",
-                    "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
-                    "name": "yrday_local",
-                    "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+                    "@type": "Person",
+                    "@id": "https://orcid.org/0000-0002-8341-2830",
+                    "name": "Giuseppe Amatulli",
+                    "url": "https://orcid.org/0000-0002-8341-2830"
                 }
-            ],
-            "funding": {
-                "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
-                "@type": "MonetaryGrant",
-                "identifier": "9909933",
-                "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
-                "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
-                "funder": {
-                    "@id": "http://dx.doi.org/10.13039/100000001",
-                    "@type": "Organization",
-                    "name": "National Science Foundation",
-                    "identifier": [
-                        "http://dx.doi.org/10.13039/100000001",
-                        "https://ror.org/021nxhr62"
-                    ]
+            ]
+        },
+        "citation": "Amatulli, G., Garcia Marquez, J., Sethi, T., Kiesel, J., Grigoropoulou, A., Üblacker, M. M., Shen, L. Q., and Domisch, S.: Hydrography90m: a new high-resolution global hydrographic dataset, Earth Syst. Sci. Data, 14, 4525–4550, https://doi.org/10.5194/essd-14-4525-2022, 2022.",
+        "version": "1",
+        "license": "https://creativecommons.org/licenses/by/4.0/",
+        "temporalCoverage": "2001-08-06/2002-09-09",
+        "spatialCoverage": {
+            "@type": "Place",
+            "geo": {
+                "@type": "GeoShape",
+                "box": "-68.4817 -75.8183 -65.08 -68.5033"
+            },
+            "additionalProperty": [
+                {
+                    "@type": "PropertyValue",
+                    "propertyID": "http://www.wikidata.org/entity/Q4018860",
+                    "name": "well-known text (WKT) representation of geometry",
+                    "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))"
+                },
+                {
+                    "@type": "PropertyValue",
+                    "propertyID": "http://www.wikidata.org/entity/Q161779",
+                    "name": "Spatial Reference System",
+                    "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
                 }
+            ]
+        },
+        "variableMeasured": [
+            {
+                "@type": "PropertyValue",
+                "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+                "name": "cruiseid",
+                "description": "cruise identification",
+                "unitText": "text"
+            },
+            {
+                "@type": "PropertyValue",
+                "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+                "name": "year",
+                "description": "year of experiment",
+                "unitText": "calendar year"
+            },
+            {
+                "@type": "PropertyValue",
+                "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+                "name": "sample_id",
+                "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection"
+            },
+            {
+                "@type": "PropertyValue",
+                "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+                "name": "time_sample",
+                "description": "Number of minutes between collection and sampling for pigment content; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
+                "unitText": "minutes"
+            },
+            {
+                "@type": "PropertyValue",
+                "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+                "name": "pigment_content",
+                "description": "pigment content",
+                "unitText": "micrograms total chl/grams wet weight"
+            },
+            {
+                "@type": "PropertyValue",
+                "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+                "name": "stage_id",
+                "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)"
+            },
+            {
+                "@type": "PropertyValue",
+                "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+                "name": "wet_weight",
+                "description": "average wet weight/larvae in sample",
+                "unitText": "mg"
+            },
+            {
+                "@type": "PropertyValue",
+                "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+                "name": "lat",
+                "description": "latitude, in decimal degrees, North is positive, negative denotes South",
+                "unitText": "decimal degrees"
+            },
+            {
+                "@type": "PropertyValue",
+                "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+                "name": "lon",
+                "description": "longitude, in decimal degrees, East is positive, negative denotes West",
+                "unitText": "decimal degrees"
+            },
+            {
+                "@type": "PropertyValue",
+                "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+                "name": "day_local",
+                "description": "day of month, local time"
+            },
+            {
+                "@type": "PropertyValue",
+                "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+                "name": "month_local",
+                "description": "month, local time"
+            },
+            {
+                "@type": "PropertyValue",
+                "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+                "name": "time_local",
+                "description": "time of day, local time, using 2400 clock format"
+            },
+            {
+                "@type": "PropertyValue",
+                "propertyID": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+                "name": "yrday_local",
+                "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)"
+            }
+        ],
+        "funding": {
+            "@id": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+            "@type": "MonetaryGrant",
+            "identifier": "9909933",
+            "name": "GLOBEC: Winter Ecology of Larval Krill: Quantifying their Interaction with the Pack Ice Habitat",
+            "url": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=9909933",
+            "funder": {
+                "@id": "http://dx.doi.org/10.13039/100000001",
+                "@type": "Organization",
+                "name": "National Science Foundation",
+                "identifier": [
+                    "http://dx.doi.org/10.13039/100000001",
+                    "https://ror.org/021nxhr62"
+                ]
             }
         }
-
-        let dists = []
-        for (const baseUrl of baseUrls) {
-            const specificUrl = baseUrl.replace(/\${tiles[tile]}/g, tiles[tile]);
-            let dist = {
-                '@type' : "DataDownload",
-                "contentUrl":specificUrl,
-            }
-            if (specificUrl.endsWith(".gpkg")) {
-                dist["encodingFormat"]= "application/geopackage+vnd.sqlite3";
-            } else {
-                dist["encodingFormat"]= "image/tiff";
-            }
-            dists.push(dist)
-            // console.log("{\n" +
-            //     "  \"@type\": \"DataDownload\",\n" +
-            //     "  \"contentUrl\": \"" + specificUrl + "\",");
-            // if (specificUrl.endsWith(".gpkg")) {
-            //     console.log("  \"encodingFormat\": \"application/geopackage+vnd.sqlite3\"\n" +
-            //         "},");
-            // } else {
-            //     console.log("  \"encodingFormat\": \"image/tiff\"\n" +
-            //         "},");
-            // }
-        }
-        let jsonObj = header
-        jsonObj["distributions"] = dists
-       // const distribution = JSON.stringify(dists,undefined, 2)
-       // const output = `${header} , "distributions": ${distribution}`
-        //console.log(output)
-        let output =JSON.stringify(jsonObj,undefined, 2)
-        console.log(output)
-        fs.writeFile(`jsonld/hydrograph_tile_${tiles[tile]}.json`, output, (err) => {
-
-            // In case of a error throw err.
-            if (err) throw err;
-        })
     }
+
+    let dists = []
+    for (const baseUrl of tileUrls) {
+        const specificUrl = baseUrl.replace(/\${tile}/g, tiles[tile]);
+        let dist = {
+            '@type': "DataDownload",
+            "contentUrl": specificUrl,
+        }
+        if (specificUrl.endsWith(".gpkg")) {
+            dist["encodingFormat"] = "application/geopackage+vnd.sqlite3";
+        } else {
+            dist["encodingFormat"] = "image/tiff";
+        }
+        dists.push(dist)
+        // console.log("{\n" +
+        //     "  \"@type\": \"DataDownload\",\n" +
+        //     "  \"contentUrl\": \"" + specificUrl + "\",");
+        // if (specificUrl.endsWith(".gpkg")) {
+        //     console.log("  \"encodingFormat\": \"application/geopackage+vnd.sqlite3\"\n" +
+        //         "},");
+        // } else {
+        //     console.log("  \"encodingFormat\": \"image/tiff\"\n" +
+        //         "},");
+        // }
+    }
+    let jsonObj = header
+    jsonObj["distributions"] = dists
+    // const distribution = JSON.stringify(dists,undefined, 2)
+    // const output = `${header} , "distributions": ${distribution}`
+    //console.log(output)
+    let output = JSON.stringify(jsonObj, undefined, 2)
+    console.log(output)
+    const filename = `jsonld/hydrograph_tile_${tiles[tile]}.json`
+    sitemapFiles.push(filename)
+    fs.writeFile(`../../${filename}`, output, (err) => {
+
+        // In case of a error throw err.
+        if (err) throw err;
+    })
+    const files = sitemapFiles.map(f => `<sitemap>
+    <loc>${baseUrl}${f}</loc>
+  </sitemap> `)
+
+    const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+        ${files.join("\n")}
+</sitemapindex>`
+
+    fs.writeFile(`../../jsonld/sitemap_json.xml`, sitemap, (err) => {
+
+        // In case of a error throw err.
+        if (err) throw err;
+    })
+
+}
 
 


### PR DESCRIPTION
Rather than one big JSONLD (2.5 megs) embeded in a page that users download, create 112 jsonld's
create directory that is exposed by jekyll. (at least on developer serve).
and create a sitemap pointing to the files ( {some baseurl}/jsonld/sitemap_json.xml)